### PR TITLE
Rotate settings chevron 180 degrees when settings panel is open

### DIFF
--- a/src/pages/app/App.tsx
+++ b/src/pages/app/App.tsx
@@ -370,6 +370,7 @@ export default function App() {
 								style={{
 									height: '30px',
 									width: '20px',
+									transform: `rotate(${settingsView ? 180 : 0}deg)`,
 								}}
 								className={
 									'text-slate-800 group-hover:text-slate-500 h-full mx-auto'


### PR DESCRIPTION
Rotate settings chevron 180 degrees when settings panel is open to better indicate button functionality.